### PR TITLE
Fix package-lock.json sync issue for GitHub Actions

### DIFF
--- a/tools/landing-page/package-lock.json
+++ b/tools/landing-page/package-lock.json
@@ -4197,17 +4197,6 @@
         "@vue/shared": "3.5.22"
       }
     },
-    "node_modules/@vue/compiler-vue2": {
-      "version": "2.7.16",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-vue2/-/compiler-vue2-2.7.16.tgz",
-      "integrity": "sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "de-indent": "^1.0.2",
-        "he": "^1.2.0"
-      }
-    },
     "node_modules/@vue/devtools-api": {
       "version": "6.6.4",
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
@@ -4260,17 +4249,16 @@
       }
     },
     "node_modules/@vue/language-core": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.0.8.tgz",
-      "integrity": "sha512-eYs6PF7bxoPYvek9qxceo1BCwFbJZYqJll+WaYC8o8ec60exqj+n+QRGGiJHSeUfYp0hDxARbMdxMq/fbPgU5g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.1.0.tgz",
+      "integrity": "sha512-a7ns+X9vTbdmk7QLrvnZs8s4E1wwtxG/sELzr6F2j4pU+r/OoAv6jJGSz+5tVTU6e4+3rjepGhSP8jDmBBcb3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/language-core": "2.4.23",
         "@vue/compiler-dom": "^3.5.0",
-        "@vue/compiler-vue2": "^2.7.16",
         "@vue/shared": "^3.5.0",
-        "alien-signals": "^2.0.5",
+        "alien-signals": "^3.0.0",
         "muggle-string": "^0.4.1",
         "path-browserify": "^1.0.1",
         "picomatch": "^4.0.2"
@@ -4506,9 +4494,9 @@
       }
     },
     "node_modules/alien-signals": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-2.0.8.tgz",
-      "integrity": "sha512-844G1VLkk0Pe2SJjY0J8vp8ADI73IM4KliNu2OGlYzWpO28NexEUvjHTcFjFX3VXoiUtwTbHxLNI9ImkcoBqzA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.0.0.tgz",
+      "integrity": "sha512-JHoRJf18Y6HN4/KZALr3iU+0vW9LKG+8FMThQlbn4+gv8utsLIkwpomjElGPccGeNwh0FI2HN6BLnyFLo6OyLQ==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
Updated landing-page package-lock.json to sync with package.json dependencies. This fixes the npm ci failure in GitHub Actions deployment pipeline.