### PR TITLE
Fix mobile responsive layout for map distance calculator

### DIFF
--- a/tools/map-distance-calculator/components/MapContainer.vue
+++ b/tools/map-distance-calculator/components/MapContainer.vue
@@ -1,6 +1,6 @@
 <template>
   <ClientOnly>
-    <div class="relative h-full">
+    <div class="relative h-[500px] lg:h-full">
       <div ref="mapEl" class="h-full rounded-lg overflow-hidden shadow-lg"></div>
     </div>
   </ClientOnly>

--- a/tools/map-distance-calculator/pages/index.vue
+++ b/tools/map-distance-calculator/pages/index.vue
@@ -14,7 +14,7 @@
       </div>
 
       <!-- Main Content -->
-      <div class="grid grid-cols-1 lg:grid-cols-12 gap-6 h-[calc(100vh-240px)] min-h-[600px]">
+      <div class="grid grid-cols-1 lg:grid-cols-12 gap-6 lg:h-[calc(100vh-240px)] lg:min-h-[600px]">
         <!-- Sidebar -->
         <div class="lg:col-span-3 space-y-4">
           <!-- Control Buttons -->


### PR DESCRIPTION
## Summary
Fixed map display issue on mobile devices where the map appeared extremely small and unusable.

## Changes
- **MapContainer.vue**: Set mobile-specific height (500px) with responsive breakpoint
- **index.vue**: Applied viewport height constraints only on desktop (lg+ breakpoints)
- Enabled vertical scrolling on mobile for better UX

## Technical Details
### Before
- Map used `h-full` which inherited from parent's viewport-based height calculation
- On mobile, `h-[calc(100vh-240px)]` combined with other content made the map extremely compressed
- No responsive breakpoints for height constraints

### After  
- Mobile: Fixed 500px height for map, allowing natural scrolling
- Desktop (lg+): Maintains full viewport height behavior
- Proper responsive breakpoints using Tailwind's `lg:` prefix

## Testing
Tested on mobile viewport (375x667px) using:
- ✅ Chrome DevTools MCP - Mobile viewport simulation
- ✅ Playwright MCP - Automated mobile testing
- ✅ Verified map displays at proper size (500px)
- ✅ Verified marker placement and distance calculation work correctly
- ✅ Verified vertical scrolling functions properly

## Screenshots
Mobile view now shows map at 500px height with proper scrolling:
- Distance information panel displays correctly
- Map is fully interactive (markers, zoom, pan)
- All controls remain accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)