### PR TITLE
chore: Biome + Oxlint 導入（TS フォーマット・lint 基盤）

### DIFF
--- a/.claude/hooks/post-tool-use-format-and-lint.sh
+++ b/.claude/hooks/post-tool-use-format-and-lint.sh
@@ -1,70 +1,77 @@
 #!/usr/bin/env python3
 """
 Post-tool-use hook: auto-format and lint Vue/TS files after edits.
-Reads the Claude hook JSON payload from stdin. For files under tools/*/
-with .vue or .ts extensions, runs `npm run lint --if-present` in the
-tool's directory. Failures are ignored to avoid breaking the workflow.
+
+Logic:
+  - .vue in tools/*/          → per-tool ESLint
+  - .ts in Biome scope        → biome format --write + oxlint
+  - .ts in tools/ (non-scope) → per-tool ESLint
 """
+import json, os, re, subprocess, sys
 
-import json
-import os
-import subprocess
-import sys
+BIOME_SCOPE = [
+    re.compile(r'^tests/'),
+    re.compile(r'^tools/[^/]+/utils/'),
+    re.compile(r'^tools/shared/'),
+    re.compile(r'^vitest\.config\.ts$'),
+    re.compile(r'^playwright\.config\.ts$'),
+]
 
 
-def get_tool_dir(file_path: str, project_dir: str) -> str | None:
-    """Return the tool root directory if the file belongs to a tool, else None."""
-    # Normalise to an absolute path
-    if not os.path.isabs(file_path):
-        file_path = os.path.join(project_dir, file_path)
-    rel = os.path.relpath(file_path, project_dir)
+def rel(path, root):
+    if not os.path.isabs(path):
+        path = os.path.join(root, path)
+    return os.path.relpath(path, root)
 
-    # Expect: tools/<tool-name>/...
-    parts = rel.split(os.sep)
-    if len(parts) >= 2 and parts[0] == "tools":
-        tool_dir = os.path.join(project_dir, parts[0], parts[1])
-        if os.path.isdir(tool_dir):
-            return tool_dir
+
+def is_biome_scope(r):
+    return any(p.match(r) for p in BIOME_SCOPE)
+
+
+def tool_dir(r, root):
+    parts = r.split(os.sep)
+    if len(parts) >= 2 and parts[0] == 'tools' and parts[1] != 'shared':
+        d = os.path.join(root, parts[0], parts[1])
+        return d if os.path.isdir(d) else None
     return None
 
 
-def should_lint(file_path: str) -> bool:
-    """Return True if the file extension warrants linting."""
-    return file_path.endswith((".vue", ".ts"))
+def run(cmd, cwd=None):
+    try:
+        subprocess.run(cmd, cwd=cwd, capture_output=True, timeout=60)
+    except Exception:
+        pass
 
 
-def main() -> None:
+def main():
     try:
         payload = json.load(sys.stdin)
     except (json.JSONDecodeError, EOFError):
         sys.exit(0)
 
-    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
-
-    # The file path is in tool_input for Edit/Write tools
-    tool_input = payload.get("tool_input", {})
-    file_path = tool_input.get("file_path", "")
-
-    if not file_path or not should_lint(file_path):
+    root = os.environ.get('CLAUDE_PROJECT_DIR', os.getcwd())
+    fp = payload.get('tool_input', {}).get('file_path', '')
+    if not fp:
         sys.exit(0)
 
-    tool_dir = get_tool_dir(file_path, project_dir)
-    if not tool_dir:
-        sys.exit(0)
+    r = rel(fp, root)
+    abs_fp = os.path.join(root, r)
 
-    # Run lint; ignore failures so we never break the workflow
-    try:
-        subprocess.run(
-            ["npm", "run", "lint", "--if-present"],
-            cwd=tool_dir,
-            capture_output=True,
-            timeout=60,
-        )
-    except Exception:
-        pass
+    if fp.endswith('.vue'):
+        d = tool_dir(r, root)
+        if d:
+            run(['npm', 'run', 'lint', '--if-present'], cwd=d)
+    elif fp.endswith('.ts'):
+        if is_biome_scope(r):
+            run(['npx', 'biome', 'format', '--write', abs_fp], cwd=root)
+            run(['npx', 'oxlint', abs_fp], cwd=root)
+        else:
+            d = tool_dir(r, root)
+            if d:
+                run(['npm', 'run', 'lint', '--if-present'], cwd=d)
 
     sys.exit(0)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oxc-project/oxc/main/crates/oxc_linter/src/config/schema.json",
+  "plugins": ["typescript"],
+  "env": {
+    "es2020": true,
+    "node": true
+  },
+  "globals": {
+    "describe": "readonly",
+    "it": "readonly",
+    "test": "readonly",
+    "expect": "readonly",
+    "beforeEach": "readonly",
+    "afterEach": "readonly",
+    "beforeAll": "readonly",
+    "afterAll": "readonly"
+  },
+  "rules": {
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-explicit-any": "warn",
+    "@typescript-eslint/no-non-null-assertion": "warn",
+    "@typescript-eslint/no-unnecessary-type-assertion": "error",
+    "@typescript-eslint/prefer-nullish-coalescing": "warn",
+    "@typescript-eslint/prefer-optional-chain": "warn"
+  },
+  "overrides": [
+    {
+      "files": ["tests/**/*.ts"],
+      "rules": {
+        "@typescript-eslint/no-explicit-any": "off"
+      }
+    }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,3 @@
 # CLAUDE.md
 
 See `./AGENTS.md` for repository instructions.
-

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-unit test-unit-watch test-unit-coverage test-e2e test-e2e-dev test-all lint help
+.PHONY: test test-unit test-unit-watch test-unit-coverage test-e2e test-e2e-dev test-all lint lint-tool format format-check check help
 
 # Default target
 .DEFAULT_GOAL := test
@@ -31,14 +31,30 @@ test-e2e-dev:
 test-all:
 	npm run test:unit && npm run test:e2e
 
-## Run ESLint for a specific tool (TOOL=ip-calculator required)
+## Format Biome-scope TS files in place
+format:
+	npx biome format --write tests/ tools/*/utils/ tools/shared/ vitest.config.ts playwright.config.ts
+
+## Check formatting (non-destructive, exits 1 if changes needed)
+format-check:
+	npx biome format tests/ tools/*/utils/ tools/shared/ vitest.config.ts playwright.config.ts
+
+## Run Biome + Oxlint on Biome-scope TS files
 lint:
+	npx biome lint --diagnostic-level=error tests/ tools/*/utils/ tools/shared/ vitest.config.ts playwright.config.ts
+	npx oxlint tests/ tools/*/utils/ tools/shared/ vitest.config.ts playwright.config.ts
+
+## Run ESLint for a specific tool (TOOL=ip-calculator required)
+lint-tool:
 ifdef TOOL
 	cd tools/$(TOOL) && npx eslint .
 else
-	@echo "Usage: make lint TOOL=<tool-name>"
-	@echo "Example: make lint TOOL=ip-calculator"
+	@echo "Usage: make lint-tool TOOL=<tool-name>"
 endif
+
+## Format + lint + import organize in one pass
+check:
+	npx biome check --write tests/ tools/*/utils/ tools/shared/ vitest.config.ts playwright.config.ts
 
 ## Show available targets
 help:

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.7/schema.json",
+  "files": {
+    "includes": [
+      "tests/**/*.ts",
+      "tools/*/utils/**/*.ts",
+      "tools/shared/**/*.ts",
+      "vitest.config.ts",
+      "playwright.config.ts",
+      "!node_modules/**",
+      "!coverage/**",
+      "!tools/**/.nuxt/**",
+      "!tools/**/dist/**",
+      "!tools/**/.output/**"
+    ]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "trailingCommas": "es5",
+      "semicolons": "asNeeded",
+      "arrowParentheses": "asNeeded"
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "correctness": {
+        "noUnusedVariables": "warn",
+        "noUnusedImports": "warn",
+        "useExhaustiveDependencies": "off"
+      },
+      "suspicious": {
+        "noExplicitAny": "warn",
+        "noConsole": "warn"
+      },
+      "complexity": {
+        "noForEach": "off"
+      },
+      "style": {
+        "noNonNullAssertion": "warn",
+        "useConst": "error",
+        "useImportType": "warn"
+      }
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,5 +1,25 @@
 pre-commit:
   commands:
+    format-check:
+      glob: "*.ts"
+      run: |
+        BIOME_FILES=$(echo {staged_files} | tr ' ' '\n' | grep -E \
+          '^(tests/|tools/[^/]+/utils/|tools/shared/|vitest\.config\.ts$|playwright\.config\.ts$)' \
+          | tr '\n' ' ')
+        if [ -n "$BIOME_FILES" ]; then
+          npx biome format $BIOME_FILES
+        fi
+      fail_text: "Biome format check failed. Run: npm run format"
+    lint-staged:
+      glob: "*.ts"
+      run: |
+        BIOME_FILES=$(echo {staged_files} | tr ' ' '\n' | grep -E \
+          '^(tests/|tools/[^/]+/utils/|tools/shared/|vitest\.config\.ts$|playwright\.config\.ts$)' \
+          | tr '\n' ' ')
+        if [ -n "$BIOME_FILES" ]; then
+          npx biome lint --diagnostic-level=error $BIOME_FILES && npx oxlint $BIOME_FILES
+        fi
+      fail_text: "Lint errors found. Run: npm run lint"
     unit-tests:
       run: npx vitest run
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
         "jsdom": "^29.0.0"
       },
       "devDependencies": {
+        "@biomejs/biome": "2.4.7",
         "@playwright/test": "^1.53.2",
         "@types/he": "^1.2.3",
         "@types/js-yaml": "^4.0.9",
@@ -15,6 +16,7 @@
         "he": "^1.2.0",
         "js-yaml": "^4.1.0",
         "lefthook": "^1.6.0",
+        "oxlint": "1.56.0",
         "playwright": "^1.53.2",
         "toml": "^3.0.0",
         "typescript": "^5.2.0",
@@ -147,6 +149,169 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.7.tgz",
+      "integrity": "sha512-vXrgcmNGZ4lpdwZSpMf1hWw1aWS6B+SyeSYKTLrNsiUsAdSRN0J4d/7mF3ogJFbIwFFSOL3wT92Zzxia/d5/ng==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.4.7",
+        "@biomejs/cli-darwin-x64": "2.4.7",
+        "@biomejs/cli-linux-arm64": "2.4.7",
+        "@biomejs/cli-linux-arm64-musl": "2.4.7",
+        "@biomejs/cli-linux-x64": "2.4.7",
+        "@biomejs/cli-linux-x64-musl": "2.4.7",
+        "@biomejs/cli-win32-arm64": "2.4.7",
+        "@biomejs/cli-win32-x64": "2.4.7"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.7.tgz",
+      "integrity": "sha512-Oo0cF5mHzmvDmTXw8XSjhCia8K6YrZnk7aCS54+/HxyMdZMruMO3nfpDsrlar/EQWe41r1qrwKiCa2QDYHDzWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.7.tgz",
+      "integrity": "sha512-I+cOG3sd/7HdFtvDSnF9QQPrWguUH7zrkIMMykM3PtfWU9soTcS2yRb9Myq6MHmzbeCT08D1UmY+BaiMl5CcoQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.7.tgz",
+      "integrity": "sha512-om6FugwmibzfP/6ALj5WRDVSND4H2G9X0nkI1HZpp2ySf9lW2j0X68oQSaHEnls6666oy4KDsc5RFjT4m0kV0w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.7.tgz",
+      "integrity": "sha512-I2NvM9KPb09jWml93O2/5WMfNR7Lee5Latag1JThDRMURVhPX74p9UDnyTw3Ae6cE1DgXfw7sqQgX7rkvpc0vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.7.tgz",
+      "integrity": "sha512-bV8/uo2Tj+gumnk4sUdkerWyCPRabaZdv88IpbmDWARQQoA/Q0YaqPz1a+LSEDIL7OfrnPi9Hq1Llz4ZIGyIQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.7.tgz",
+      "integrity": "sha512-00kx4YrBMU8374zd2wHuRV5wseh0rom5HqRND+vDldJPrWwQw+mzd/d8byI9hPx926CG+vWzq6AeiT7Yi5y59g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.7.tgz",
+      "integrity": "sha512-hOUHBMlFCvDhu3WCq6vaBoG0dp0LkWxSEnEEsxxXvOa9TfT6ZBnbh72A/xBM7CBYB7WgwqboetzFEVDnMxelyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.7.tgz",
+      "integrity": "sha512-qEpGjSkPC3qX4ycbMUthXvi9CkRq7kZpkqMY1OyhmYlYLnANnooDQ7hDerM8+0NJ+DZKVnsIc07h30XOpt7LtQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
     },
     "node_modules/@bramus/specificity": {
       "version": "2.4.2",
@@ -767,6 +932,329 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm-eabi": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.56.0.tgz",
+      "integrity": "sha512-IyfYPthZyiSKwAv/dLjeO18SaK8MxLI9Yss2JrRDyweQAkuL3LhEy7pwIwI7uA3KQc1Vdn20kdmj3q0oUIQL6A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm64": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.56.0.tgz",
+      "integrity": "sha512-Ga5zYrzH6vc/VFxhn6MmyUnYEfy9vRpwTIks99mY3j6Nz30yYpIkWryI0QKPCgvGUtDSXVLEaMum5nA+WrNOSg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-arm64": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.56.0.tgz",
+      "integrity": "sha512-ogmbdJysnw/D4bDcpf1sPLpFThZ48lYp4aKYm10Z/6Nh1SON6NtnNhTNOlhEY296tDFItsZUz+2tgcSYqh8Eyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-x64": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.56.0.tgz",
+      "integrity": "sha512-x8QE1h+RAtQ2g+3KPsP6Fk/tdz6zJQUv5c7fTrJxXV3GHOo+Ry5p/PsogU4U+iUZg0rj6hS+E4xi+mnwwlDCWQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-freebsd-x64": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.56.0.tgz",
+      "integrity": "sha512-6G+WMZvwJpMvY7my+/SHEjb7BTk/PFbePqLpmVmUJRIsJMy/UlyYqjpuh0RCgYYkPLcnXm1rUM04kbTk8yS1Yg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.56.0.tgz",
+      "integrity": "sha512-YYHBsk/sl7fYwQOok+6W5lBPeUEvisznV/HZD2IfZmF3Bns6cPC3Z0vCtSEOaAWTjYWN3jVsdu55jMxKlsdlhg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-musleabihf": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.56.0.tgz",
+      "integrity": "sha512-+AZK8rOUr78y8WT6XkDb04IbMRqauNV+vgT6f8ZLOH8wnpQ9i7Nol0XLxAu+Cq7Sb+J9wC0j6Km5hG8rj47/yQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-gnu": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.56.0.tgz",
+      "integrity": "sha512-urse2SnugwJRojUkGSSeH2LPMaje5Q50yQtvtL9HFckiyeqXzoFwOAZqD5TR29R2lq7UHidfFDM9EGcchcbb8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-musl": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.56.0.tgz",
+      "integrity": "sha512-rkTZkBfJ4TYLjansjSzL6mgZOdN5IvUnSq3oNJSLwBcNvy3dlgQtpHPrRxrCEbbcp7oQ6If0tkNaqfOsphYZ9g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-ppc64-gnu": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.56.0.tgz",
+      "integrity": "sha512-uqL1kMH3u69/e1CH2EJhP3CP28jw2ExLsku4o8RVAZ7fySo9zOyI2fy9pVlTAp4voBLVgzndXi3SgtdyCTa2aA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-gnu": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.56.0.tgz",
+      "integrity": "sha512-j0CcMBOgV6KsRaBdsebIeiy7hCjEvq2KdEsiULf2LZqAq0v1M1lWjelhCV57LxsqaIGChXFuFJ0RiFrSRHPhSg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-musl": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.56.0.tgz",
+      "integrity": "sha512-7VDOiL8cDG3DQ/CY3yKjbV1c4YPvc4vH8qW09Vv+5ukq3l/Kcyr6XGCd5NvxUmxqDb2vjMpM+eW/4JrEEsUetA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-s390x-gnu": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.56.0.tgz",
+      "integrity": "sha512-JGRpX0M+ikD3WpwJ7vKcHKV6Kg0dT52BW2Eu2BupXotYeqGXBrbY+QPkAyKO6MNgKozyTNaRh3r7g+VWgyAQYQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-gnu": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.56.0.tgz",
+      "integrity": "sha512-dNaICPvtmuxFP/VbqdofrLqdS3bM/AKJN3LMJD52si44ea7Be1cBk6NpfIahaysG9Uo+L98QKddU9CD5L8UHnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-musl": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.56.0.tgz",
+      "integrity": "sha512-pF1vOtM+GuXmbklM1hV8WMsn6tCNPvkUzklj/Ej98JhlanbmA2RB1BILgOpwSuCTRTIYx2MXssmEyQQ90QF5aA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-openharmony-arm64": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.56.0.tgz",
+      "integrity": "sha512-bp8NQ4RE6fDIFLa4bdBiOA+TAvkNkg+rslR+AvvjlLTYXLy9/uKAYLQudaQouWihLD/hgkrXIKKzXi5IXOewwg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-arm64-msvc": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.56.0.tgz",
+      "integrity": "sha512-PxT4OJDfMOQBzo3OlzFb9gkoSD+n8qSBxyVq2wQSZIHFQYGEqIRTo9M0ZStvZm5fdhMqaVYpOnJvH2hUMEDk/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-ia32-msvc": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.56.0.tgz",
+      "integrity": "sha512-PTRy6sIEPqy2x8PTP1baBNReN/BNEFmde0L+mYeHmjXE1Vlcc9+I5nsqENsB2yAm5wLkzPoTNCMY/7AnabT4/A==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-x64-msvc": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.56.0.tgz",
+      "integrity": "sha512-ZHa0clocjLmIDr+1LwoWtxRcoYniAvERotvwKUYKhH41NVfl0Y4LNbyQkwMZzwDvKklKGvGZ5+DAG58/Ik47tQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -2164,6 +2652,51 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/oxlint": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.56.0.tgz",
+      "integrity": "sha512-Q+5Mj5PVaH/R6/fhMMFzw4dT+KPB+kQW4kaL8FOIq7tfhlnEVp6+3lcWqFruuTNlUo9srZUW3qH7Id4pskeR6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "oxlint": "bin/oxlint"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxlint/binding-android-arm-eabi": "1.56.0",
+        "@oxlint/binding-android-arm64": "1.56.0",
+        "@oxlint/binding-darwin-arm64": "1.56.0",
+        "@oxlint/binding-darwin-x64": "1.56.0",
+        "@oxlint/binding-freebsd-x64": "1.56.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.56.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.56.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.56.0",
+        "@oxlint/binding-linux-arm64-musl": "1.56.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.56.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.56.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.56.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.56.0",
+        "@oxlint/binding-linux-x64-gnu": "1.56.0",
+        "@oxlint/binding-linux-x64-musl": "1.56.0",
+        "@oxlint/binding-openharmony-arm64": "1.56.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.56.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.56.0",
+        "@oxlint/binding-win32-x64-msvc": "1.56.0"
+      },
+      "peerDependencies": {
+        "oxlint-tsgolint": ">=0.15.0"
+      },
+      "peerDependenciesMeta": {
+        "oxlint-tsgolint": {
+          "optional": true
+        }
       }
     },
     "node_modules/package-json-from-dist": {

--- a/package.json
+++ b/package.json
@@ -6,9 +6,16 @@
     "test:unit:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:all": "npm run test:unit && npm run test:e2e",
-    "prepare": "lefthook install"
+    "prepare": "lefthook install",
+    "format": "biome format --write tests/ tools/*/utils/ tools/shared/ vitest.config.ts playwright.config.ts",
+    "format:check": "biome format tests/ tools/*/utils/ tools/shared/ vitest.config.ts playwright.config.ts",
+    "lint": "biome lint --diagnostic-level=error tests/ tools/*/utils/ tools/shared/ vitest.config.ts playwright.config.ts && oxlint tests/ tools/*/utils/ tools/shared/ vitest.config.ts playwright.config.ts",
+    "lint:biome": "biome lint --diagnostic-level=error tests/ tools/*/utils/ tools/shared/ vitest.config.ts playwright.config.ts",
+    "lint:oxlint": "oxlint tests/ tools/*/utils/ tools/shared/ vitest.config.ts playwright.config.ts",
+    "check": "biome check --write tests/ tools/*/utils/ tools/shared/ vitest.config.ts playwright.config.ts"
   },
   "devDependencies": {
+    "@biomejs/biome": "2.4.7",
     "@playwright/test": "^1.53.2",
     "@types/he": "^1.2.3",
     "@types/js-yaml": "^4.0.9",
@@ -16,6 +23,7 @@
     "he": "^1.2.0",
     "js-yaml": "^4.1.0",
     "lefthook": "^1.6.0",
+    "oxlint": "1.56.0",
     "playwright": "^1.53.2",
     "toml": "^3.0.0",
     "typescript": "^5.2.0",

--- a/tests/e2e/character-code-converter.spec.ts
+++ b/tests/e2e/character-code-converter.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { expect, test } from '@playwright/test'
 import { getToolUrl } from './helpers/url'
 
 const BASE_URL = getToolUrl('character-code-converter')

--- a/tests/e2e/hash-generator.spec.ts
+++ b/tests/e2e/hash-generator.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { expect, test } from '@playwright/test'
 import { getToolUrl } from './helpers/url'
 
 const BASE_URL = getToolUrl('hash-generator')
@@ -22,7 +22,9 @@ test.describe('Hash Generator', () => {
     await input.fill('hello')
 
     // SHA-256 of "hello"
-    await expect(page.getByText('2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824')).toBeVisible()
+    await expect(
+      page.getByText('2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824')
+    ).toBeVisible()
   })
 
   test('shows empty state with no input', async ({ page }) => {

--- a/tests/e2e/helpers/url.ts
+++ b/tests/e2e/helpers/url.ts
@@ -16,13 +16,10 @@ const toolPorts: Record<string, number> = {
 export function getToolUrl(tool: string, path = ''): string {
   let base: string
   if (TARGET === 'prd') {
-    base = tool === 'landing-page'
-      ? 'https://devtools.site'
-      : `https://${tool}.devtools.site`
+    base = tool === 'landing-page' ? 'https://devtools.site' : `https://${tool}.devtools.site`
   } else if (TARGET === 'dev') {
-    base = tool === 'landing-page'
-      ? 'https://dev.devtools.site'
-      : `https://${tool}.dev.devtools.site`
+    base =
+      tool === 'landing-page' ? 'https://dev.devtools.site' : `https://${tool}.dev.devtools.site`
   } else {
     const port = toolPorts[tool] ?? 3000
     base = `http://localhost:${port}`

--- a/tests/e2e/ip-calculator.spec.ts
+++ b/tests/e2e/ip-calculator.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { expect, test } from '@playwright/test'
 import { getToolUrl } from './helpers/url'
 
 const BASE_URL = getToolUrl('ip-calculator')
@@ -16,7 +16,9 @@ test.describe('IP Calculator', () => {
     await expect(page.getByText('255.255.255.0')).toBeVisible()
     await expect(page.getByText('192.168.1.0')).toBeVisible()
     await expect(page.getByText('192.168.1.255')).toBeVisible()
-    await expect(page.getByText('Class C', { exact: false }).or(page.getByText('C', { exact: true }))).toBeVisible()
+    await expect(
+      page.getByText('Class C', { exact: false }).or(page.getByText('C', { exact: true }))
+    ).toBeVisible()
   })
 
   test('shows correct usable host count for /24', async ({ page }) => {

--- a/tests/e2e/json-yaml-converter.spec.ts
+++ b/tests/e2e/json-yaml-converter.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { expect, test } from '@playwright/test'
 import { getToolUrl } from './helpers/url'
 
 const BASE_URL = getToolUrl('json-yaml-converter')

--- a/tests/e2e/jwt-decoder.spec.ts
+++ b/tests/e2e/jwt-decoder.spec.ts
@@ -1,10 +1,11 @@
-import { test, expect } from '@playwright/test'
+import { expect, test } from '@playwright/test'
 import { getToolUrl } from './helpers/url'
 
 const BASE_URL = getToolUrl('jwt-decoder')
 
 // Sample JWT for testing
-const SAMPLE_JWT = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
+const SAMPLE_JWT =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
 
 test.describe('JWT Decoder', () => {
   test.beforeEach(async ({ page }) => {

--- a/tests/e2e/markdown-preview.spec.ts
+++ b/tests/e2e/markdown-preview.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { expect, test } from '@playwright/test'
 import { getToolUrl } from './helpers/url'
 
 const BASE_URL = getToolUrl('markdown-preview')

--- a/tests/e2e/password-generator.spec.ts
+++ b/tests/e2e/password-generator.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { expect, test } from '@playwright/test'
 import { getToolUrl } from './helpers/url'
 
 const BASE_URL = getToolUrl('password-generator')

--- a/tests/e2e/regex-tester.spec.ts
+++ b/tests/e2e/regex-tester.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { expect, test } from '@playwright/test'
 import { getToolUrl } from './helpers/url'
 
 const BASE_URL = getToolUrl('regex-tester')

--- a/tests/e2e/string-converter.spec.ts
+++ b/tests/e2e/string-converter.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { expect, test } from '@playwright/test'
 import { getToolUrl } from './helpers/url'
 
 const BASE_URL = getToolUrl('string-converter')

--- a/tests/e2e/unix-time-converter.spec.ts
+++ b/tests/e2e/unix-time-converter.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { expect, test } from '@playwright/test'
 import { getToolUrl } from './helpers/url'
 
 const BASE_URL = getToolUrl('unix-time-converter')

--- a/tests/unit/character-code-converter/char-code-utils.test.ts
+++ b/tests/unit/character-code-converter/char-code-utils.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect } from 'vitest'
-import { convertChar, encodeFullText } from '../../../tools/character-code-converter/utils/char-code-utils'
+import { describe, expect, it } from 'vitest'
+import {
+  convertChar,
+  encodeFullText,
+} from '../../../tools/character-code-converter/utils/char-code-utils'
 
 describe('convertChar', () => {
   it('converts ASCII character "A"', () => {

--- a/tests/unit/ip-calculator/ip-utils.test.ts
+++ b/tests/unit/ip-calculator/ip-utils.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from 'vitest'
-import { calculateIP, isValidIP, intToIP, ipToBinary, getNetworkClass } from '../../../tools/ip-calculator/utils/ip-utils'
+import { describe, expect, it } from 'vitest'
+import {
+  calculateIP,
+  getNetworkClass,
+  intToIP,
+  ipToBinary,
+  isValidIP,
+} from '../../../tools/ip-calculator/utils/ip-utils'
 
 describe('isValidIP', () => {
   it('returns true for valid IPv4 addresses', () => {
@@ -20,9 +26,9 @@ describe('isValidIP', () => {
 
 describe('intToIP', () => {
   it('converts integer to IP address string', () => {
-    expect(intToIP(0xC0A80101)).toBe('192.168.1.1')
+    expect(intToIP(0xc0a80101)).toBe('192.168.1.1')
     expect(intToIP(0x00000000)).toBe('0.0.0.0')
-    expect(intToIP(0xFFFFFFFF)).toBe('255.255.255.255')
+    expect(intToIP(0xffffffff)).toBe('255.255.255.255')
   })
 })
 

--- a/tests/unit/json-yaml-converter/json-yaml-utils.test.ts
+++ b/tests/unit/json-yaml-converter/json-yaml-utils.test.ts
@@ -1,9 +1,13 @@
-import { describe, it, expect } from 'vitest'
-import { parseInput, formatOutput, stringifyToml } from '../../../tools/json-yaml-converter/utils/json-yaml-utils'
+import { describe, expect, it } from 'vitest'
+import {
+  formatOutput,
+  parseInput,
+  stringifyToml,
+} from '../../../tools/json-yaml-converter/utils/json-yaml-utils'
 
 const defaultFormatOptions = {
   prettyFormat: true,
-  jsonIndent: '2'
+  jsonIndent: '2',
 }
 
 const sampleData = { name: 'John', age: 30, active: true }

--- a/tests/unit/jwt-decoder/jwt-utils.test.ts
+++ b/tests/unit/jwt-decoder/jwt-utils.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from 'vitest'
-import { getAlgorithmDescription, formatTimestamp, formatClaimValue } from '../../../tools/jwt-decoder/utils/jwt-utils'
+import { describe, expect, it } from 'vitest'
+import {
+  formatClaimValue,
+  formatTimestamp,
+  getAlgorithmDescription,
+} from '../../../tools/jwt-decoder/utils/jwt-utils'
 
 describe('getAlgorithmDescription', () => {
   it('returns description for known algorithms', () => {
@@ -15,7 +19,20 @@ describe('getAlgorithmDescription', () => {
   })
 
   it('handles all standard algorithms', () => {
-    const algorithms = ['HS256', 'HS384', 'HS512', 'RS256', 'RS384', 'RS512', 'ES256', 'ES384', 'ES512', 'PS256', 'PS384', 'PS512']
+    const algorithms = [
+      'HS256',
+      'HS384',
+      'HS512',
+      'RS256',
+      'RS384',
+      'RS512',
+      'ES256',
+      'ES384',
+      'ES512',
+      'PS256',
+      'PS384',
+      'PS512',
+    ]
     for (const alg of algorithms) {
       expect(getAlgorithmDescription(alg)).not.toBe('Unknown algorithm')
     }
@@ -58,7 +75,9 @@ describe('formatClaimValue', () => {
   })
 
   it('formats array values as comma-separated string', () => {
-    expect(formatClaimValue('aud', ['api.example.com', 'example.com'])).toBe('api.example.com, example.com')
+    expect(formatClaimValue('aud', ['api.example.com', 'example.com'])).toBe(
+      'api.example.com, example.com'
+    )
   })
 
   it('converts other values to string', () => {

--- a/tests/unit/password-generator/password-utils.test.ts
+++ b/tests/unit/password-generator/password-utils.test.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect } from 'vitest'
-import { getCharacterSet, getSecureRandomInt, UPPERCASE_CHARS, LOWERCASE_CHARS, NUMBER_CHARS, SYMBOL_CHARS } from '../../../tools/password-generator/utils/password-utils'
+import { describe, expect, it } from 'vitest'
+import {
+  getCharacterSet,
+  getSecureRandomInt,
+  LOWERCASE_CHARS,
+  NUMBER_CHARS,
+  SYMBOL_CHARS,
+  UPPERCASE_CHARS,
+} from '../../../tools/password-generator/utils/password-utils'
 
 const defaultOptions = {
   includeUppercase: true,
@@ -7,22 +14,34 @@ const defaultOptions = {
   includeNumbers: true,
   includeSymbols: false,
   excludeSimilar: false,
-  excludeAmbiguous: false
+  excludeAmbiguous: false,
 }
 
 describe('getCharacterSet', () => {
   it('returns uppercase chars when only uppercase selected', () => {
-    const charset = getCharacterSet({ ...defaultOptions, includeLowercase: false, includeNumbers: false })
+    const charset = getCharacterSet({
+      ...defaultOptions,
+      includeLowercase: false,
+      includeNumbers: false,
+    })
     expect(charset).toBe(UPPERCASE_CHARS)
   })
 
   it('returns lowercase chars when only lowercase selected', () => {
-    const charset = getCharacterSet({ ...defaultOptions, includeUppercase: false, includeNumbers: false })
+    const charset = getCharacterSet({
+      ...defaultOptions,
+      includeUppercase: false,
+      includeNumbers: false,
+    })
     expect(charset).toBe(LOWERCASE_CHARS)
   })
 
   it('returns combined charset for multiple types', () => {
-    const charset = getCharacterSet({ ...defaultOptions, includeNumbers: false, includeSymbols: false })
+    const charset = getCharacterSet({
+      ...defaultOptions,
+      includeNumbers: false,
+      includeSymbols: false,
+    })
     expect(charset).toBe(UPPERCASE_CHARS + LOWERCASE_CHARS)
   })
 
@@ -36,7 +55,11 @@ describe('getCharacterSet', () => {
   })
 
   it('excludes ambiguous characters when excludeAmbiguous is true', () => {
-    const charset = getCharacterSet({ ...defaultOptions, includeSymbols: true, excludeAmbiguous: true })
+    const charset = getCharacterSet({
+      ...defaultOptions,
+      includeSymbols: true,
+      excludeAmbiguous: true,
+    })
     expect(charset).not.toContain('{')
     expect(charset).not.toContain('}')
     expect(charset).not.toContain('[')
@@ -50,7 +73,7 @@ describe('getCharacterSet', () => {
       includeNumbers: false,
       includeSymbols: false,
       excludeSimilar: false,
-      excludeAmbiguous: false
+      excludeAmbiguous: false,
     })
     expect(charset).toBe('')
   })
@@ -76,7 +99,7 @@ describe('getSecureRandomInt', () => {
     const mockCrypto = {
       getRandomValues: (arr: Uint32Array) => {
         arr[0] = 42
-      }
+      },
     }
     expect(getSecureRandomInt(100, mockCrypto)).toBe(42)
   })

--- a/tests/unit/regex-tester/regex-utils.test.ts
+++ b/tests/unit/regex-tester/regex-utils.test.ts
@@ -1,16 +1,23 @@
-import { describe, it, expect } from 'vitest'
-import { buildFlagString, parseRegexMatches, performReplace, escapeHtml } from '../../../tools/regex-tester/utils/regex-utils'
+import { describe, expect, it } from 'vitest'
+import {
+  buildFlagString,
+  escapeHtml,
+  parseRegexMatches,
+  performReplace,
+} from '../../../tools/regex-tester/utils/regex-utils'
 
 const defaultFlags = {
   global: true,
   ignoreCase: false,
   multiline: false,
-  dotAll: false
+  dotAll: false,
 }
 
 describe('buildFlagString', () => {
   it('returns empty string for no flags', () => {
-    expect(buildFlagString({ global: false, ignoreCase: false, multiline: false, dotAll: false })).toBe('')
+    expect(
+      buildFlagString({ global: false, ignoreCase: false, multiline: false, dotAll: false })
+    ).toBe('')
   })
 
   it('returns "g" for global only', () => {
@@ -22,7 +29,9 @@ describe('buildFlagString', () => {
   })
 
   it('returns "gims" for all flags', () => {
-    expect(buildFlagString({ global: true, ignoreCase: true, multiline: true, dotAll: true })).toBe('gims')
+    expect(buildFlagString({ global: true, ignoreCase: true, multiline: true, dotAll: true })).toBe(
+      'gims'
+    )
   })
 })
 
@@ -47,29 +56,35 @@ describe('parseRegexMatches', () => {
   })
 
   it('captures groups', () => {
-    const matches = parseRegexMatches('(\\w+)@(\\w+)', 'test@example', { ...defaultFlags, global: false })
+    const matches = parseRegexMatches('(\\w+)@(\\w+)', 'test@example', {
+      ...defaultFlags,
+      global: false,
+    })
     expect(matches[0].groups).toEqual(['test', 'example'])
   })
 
   it('matches case-insensitively when ignoreCase is true', () => {
-    const matches = parseRegexMatches('hello', 'Hello World HELLO', { ...defaultFlags, ignoreCase: true })
+    const matches = parseRegexMatches('hello', 'Hello World HELLO', {
+      ...defaultFlags,
+      ignoreCase: true,
+    })
     expect(matches).toHaveLength(2)
   })
 })
 
 describe('performReplace', () => {
   it('replaces first occurrence without global flag', () => {
-    const regex = new RegExp('foo')
+    const regex = /foo/
     expect(performReplace('foo bar foo', regex, 'baz')).toBe('baz bar foo')
   })
 
   it('replaces all occurrences with global flag', () => {
-    const regex = new RegExp('foo', 'g')
+    const regex = /foo/g
     expect(performReplace('foo bar foo', regex, 'baz')).toBe('baz bar baz')
   })
 
   it('supports capture group references', () => {
-    const regex = new RegExp('(\\w+)@(\\w+)', 'g')
+    const regex = /(\w+)@(\w+)/g
     expect(performReplace('user@host', regex, '$2@$1')).toBe('host@user')
   })
 })

--- a/tests/unit/shared/scroll-detection.test.ts
+++ b/tests/unit/shared/scroll-detection.test.ts
@@ -1,6 +1,10 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { calculateScrollPercentage, isPageContentShort, throttleScrollEvent } from '../../../tools/shared/utils/scroll-detection'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  calculateScrollPercentage,
+  isPageContentShort,
+  throttleScrollEvent,
+} from '../../../tools/shared/utils/scroll-detection'
 
 describe('calculateScrollPercentage', () => {
   beforeEach(() => {
@@ -13,7 +17,7 @@ describe('calculateScrollPercentage', () => {
     const mockContainer = {
       scrollTop: 0,
       scrollHeight: 1000,
-      clientHeight: 500
+      clientHeight: 500,
     } as HTMLElement
     expect(calculateScrollPercentage(mockContainer)).toBe(0)
   })
@@ -22,7 +26,7 @@ describe('calculateScrollPercentage', () => {
     const mockContainer = {
       scrollTop: 500,
       scrollHeight: 1000,
-      clientHeight: 500
+      clientHeight: 500,
     } as HTMLElement
     expect(calculateScrollPercentage(mockContainer)).toBe(100)
   })
@@ -31,7 +35,7 @@ describe('calculateScrollPercentage', () => {
     const mockContainer = {
       scrollTop: 250,
       scrollHeight: 1000,
-      clientHeight: 500
+      clientHeight: 500,
     } as HTMLElement
     expect(calculateScrollPercentage(mockContainer)).toBe(50)
   })
@@ -40,7 +44,7 @@ describe('calculateScrollPercentage', () => {
     const mockContainer = {
       scrollTop: 0,
       scrollHeight: 500,
-      clientHeight: 500
+      clientHeight: 500,
     } as HTMLElement
     expect(calculateScrollPercentage(mockContainer)).toBe(0)
   })
@@ -50,7 +54,7 @@ describe('isPageContentShort', () => {
   it('returns true when content fits in viewport', () => {
     const mockContainer = {
       scrollHeight: 400,
-      clientHeight: 500
+      clientHeight: 500,
     } as HTMLElement
     expect(isPageContentShort(mockContainer)).toBe(true)
   })
@@ -58,7 +62,7 @@ describe('isPageContentShort', () => {
   it('returns false when content is taller than viewport', () => {
     const mockContainer = {
       scrollHeight: 1000,
-      clientHeight: 500
+      clientHeight: 500,
     } as HTMLElement
     expect(isPageContentShort(mockContainer)).toBe(false)
   })

--- a/tests/unit/string-converter/string-utils.test.ts
+++ b/tests/unit/string-converter/string-utils.test.ts
@@ -1,5 +1,16 @@
-import { describe, it, expect } from 'vitest'
-import { base64Encode, base64Decode, urlEncode, urlDecode, htmlEscape, htmlUnescape, snakeToCamel, camelToSnake, toUpperCase, toLowerCase } from '../../../tools/string-converter/utils/string-utils'
+import { describe, expect, it } from 'vitest'
+import {
+  base64Decode,
+  base64Encode,
+  camelToSnake,
+  htmlEscape,
+  htmlUnescape,
+  snakeToCamel,
+  toLowerCase,
+  toUpperCase,
+  urlDecode,
+  urlEncode,
+} from '../../../tools/string-converter/utils/string-utils'
 
 describe('base64Encode / base64Decode', () => {
   it('encodes ASCII text to Base64', () => {
@@ -28,7 +39,9 @@ describe('urlEncode / urlDecode', () => {
   })
 
   it('encodes special URL characters', () => {
-    expect(urlEncode('https://example.com/search?q=test')).toBe('https%3A%2F%2Fexample.com%2Fsearch%3Fq%3Dtest')
+    expect(urlEncode('https://example.com/search?q=test')).toBe(
+      'https%3A%2F%2Fexample.com%2Fsearch%3Fq%3Dtest'
+    )
   })
 
   it('round-trips URLs', () => {
@@ -44,7 +57,9 @@ describe('urlEncode / urlDecode', () => {
 
 describe('htmlEscape / htmlUnescape', () => {
   it('escapes HTML tags', () => {
-    expect(htmlEscape('<script>alert("xss")</script>')).toBe('&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;')
+    expect(htmlEscape('<script>alert("xss")</script>')).toBe(
+      '&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;'
+    )
   })
 
   it('escapes ampersand', () => {

--- a/tests/unit/unix-time-converter/time-utils.test.ts
+++ b/tests/unit/unix-time-converter/time-utils.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest'
-import { convertUnixToHuman, convertHumanToUnix } from '../../../tools/unix-time-converter/utils/time-utils'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  convertHumanToUnix,
+  convertUnixToHuman,
+} from '../../../tools/unix-time-converter/utils/time-utils'
 
 // Use UTC timezone to make tests deterministic
 const originalTZ = process.env.TZ

--- a/tools/character-code-converter/utils/char-code-utils.ts
+++ b/tools/character-code-converter/utils/char-code-utils.ts
@@ -18,12 +18,15 @@ export function convertChar(char: string): CharacterInfo {
   const utf8Bytes = new TextEncoder().encode(char)
 
   return {
-    character: char === ' ' ? '(space)' : char === '\n' ? '(newline)' : char === '\t' ? '(tab)' : char,
+    character:
+      char === ' ' ? '(space)' : char === '\n' ? '(newline)' : char === '\t' ? '(tab)' : char,
     ascii: code <= 127 ? code.toString() : 'N/A',
     hex: '0x' + code.toString(16).toUpperCase().padStart(2, '0'),
     unicode: 'U+' + code.toString(16).toUpperCase().padStart(4, '0'),
-    utf8: Array.from(utf8Bytes).map(b => b.toString(16).toUpperCase().padStart(2, '0')).join(' '),
-    binary: code.toString(2).padStart(8, '0')
+    utf8: Array.from(utf8Bytes)
+      .map(b => b.toString(16).toUpperCase().padStart(2, '0'))
+      .join(' '),
+    binary: code.toString(2).padStart(8, '0'),
   }
 }
 
@@ -31,11 +34,12 @@ export function encodeFullText(text: string): FullTextEncodings {
   return {
     base64: btoa(unescape(encodeURIComponent(text))),
     urlEncoded: encodeURIComponent(text),
-    htmlEntities: text.split('').map(char => {
-      const code = char.charCodeAt(0)
-      return code > 127 || ['<', '>', '&', '"', "'"].includes(char)
-        ? `&#${code};`
-        : char
-    }).join('')
+    htmlEntities: text
+      .split('')
+      .map(char => {
+        const code = char.charCodeAt(0)
+        return code > 127 || ['<', '>', '&', '"', "'"].includes(char) ? `&#${code};` : char
+      })
+      .join(''),
   }
 }

--- a/tools/ip-calculator/utils/ip-utils.ts
+++ b/tools/ip-calculator/utils/ip-utils.ts
@@ -24,12 +24,7 @@ export function isValidIP(ip: string): boolean {
 }
 
 export function intToIP(int: number): string {
-  return [
-    (int >>> 24) & 0xFF,
-    (int >>> 16) & 0xFF,
-    (int >>> 8) & 0xFF,
-    int & 0xFF
-  ].join('.')
+  return [(int >>> 24) & 0xff, (int >>> 16) & 0xff, (int >>> 8) & 0xff, int & 0xff].join('.')
 }
 
 export function getNetworkClass(firstOctet: number): string {
@@ -42,7 +37,8 @@ export function getNetworkClass(firstOctet: number): string {
 }
 
 export function ipToBinary(ip: string): string {
-  return ip.split('.')
+  return ip
+    .split('.')
     .map(octet => parseInt(octet).toString(2).padStart(8, '0'))
     .join('.')
 }
@@ -67,16 +63,17 @@ export function calculateIP(input: string): IPCalculation {
   const ipParts = ipAddress.split('.').map(part => parseInt(part))
   const ipInt = (ipParts[0] << 24) + (ipParts[1] << 16) + (ipParts[2] << 8) + ipParts[3]
 
-  const subnetMaskInt = (0xFFFFFFFF << (32 - cidr)) >>> 0
+  const subnetMaskInt = (0xffffffff << (32 - cidr)) >>> 0
   const networkInt = (ipInt & subnetMaskInt) >>> 0
   // Note: JavaScript's >>> is limited to 32-bit, so special-case /32 and /0
-  const broadcastInt = cidr === 32
-    ? networkInt
-    : cidr === 0
-      ? 0xFFFFFFFF >>> 0
-      : (networkInt | (0xFFFFFFFF >>> cidr)) >>> 0
+  const broadcastInt =
+    cidr === 32
+      ? networkInt
+      : cidr === 0
+        ? 0xffffffff >>> 0
+        : (networkInt | (0xffffffff >>> cidr)) >>> 0
 
-  const totalHosts = Math.pow(2, 32 - cidr)
+  const totalHosts = 2 ** (32 - cidr)
   const usableHosts = totalHosts > 2 ? totalHosts - 2 : 0
 
   return {
@@ -91,6 +88,6 @@ export function calculateIP(input: string): IPCalculation {
     usableHosts,
     networkClass: getNetworkClass(ipParts[0]),
     ipBinary: ipToBinary(ipAddress),
-    subnetMaskBinary: ipToBinary(intToIP(subnetMaskInt))
+    subnetMaskBinary: ipToBinary(intToIP(subnetMaskInt)),
   }
 }

--- a/tools/json-yaml-converter/utils/json-yaml-utils.ts
+++ b/tools/json-yaml-converter/utils/json-yaml-utils.ts
@@ -24,20 +24,22 @@ export function parseInput(inputText: string, inputFormat: SupportedFormat): unk
   }
 }
 
-export function formatOutput(data: unknown, outputFormat: SupportedFormat, options: FormatOptions): string {
+export function formatOutput(
+  data: unknown,
+  outputFormat: SupportedFormat,
+  options: FormatOptions
+): string {
   switch (outputFormat) {
     case 'json': {
       const indentValue = options.jsonIndent === 'tab' ? '\t' : parseInt(options.jsonIndent)
-      return options.prettyFormat
-        ? JSON.stringify(data, null, indentValue)
-        : JSON.stringify(data)
+      return options.prettyFormat ? JSON.stringify(data, null, indentValue) : JSON.stringify(data)
     }
     case 'yaml':
       return yaml.dump(data, {
         indent: 2,
         lineWidth: -1,
         noRefs: true,
-        sortKeys: false
+        sortKeys: false,
       })
     case 'toml':
       return stringifyToml(data as Record<string, unknown>)

--- a/tools/jwt-decoder/utils/jwt-utils.ts
+++ b/tools/jwt-decoder/utils/jwt-utils.ts
@@ -1,17 +1,17 @@
 const ALGORITHM_DESCRIPTIONS: Record<string, string> = {
-  'HS256': 'HMAC using SHA-256',
-  'HS384': 'HMAC using SHA-384',
-  'HS512': 'HMAC using SHA-512',
-  'RS256': 'RSA using SHA-256',
-  'RS384': 'RSA using SHA-384',
-  'RS512': 'RSA using SHA-512',
-  'ES256': 'ECDSA using P-256 and SHA-256',
-  'ES384': 'ECDSA using P-384 and SHA-384',
-  'ES512': 'ECDSA using P-521 and SHA-512',
-  'PS256': 'RSA PSS using SHA-256',
-  'PS384': 'RSA PSS using SHA-384',
-  'PS512': 'RSA PSS using SHA-512',
-  'none': 'No signature'
+  HS256: 'HMAC using SHA-256',
+  HS384: 'HMAC using SHA-384',
+  HS512: 'HMAC using SHA-512',
+  RS256: 'RSA using SHA-256',
+  RS384: 'RSA using SHA-384',
+  RS512: 'RSA using SHA-512',
+  ES256: 'ECDSA using P-256 and SHA-256',
+  ES384: 'ECDSA using P-384 and SHA-384',
+  ES512: 'ECDSA using P-521 and SHA-512',
+  PS256: 'RSA PSS using SHA-256',
+  PS384: 'RSA PSS using SHA-384',
+  PS512: 'RSA PSS using SHA-512',
+  none: 'No signature',
 }
 
 export function getAlgorithmDescription(alg: string): string {

--- a/tools/password-generator/utils/password-utils.ts
+++ b/tools/password-generator/utils/password-utils.ts
@@ -23,17 +23,26 @@ export function getCharacterSet(options: PasswordOptions): string {
   if (options.includeSymbols) charset += SYMBOL_CHARS
 
   if (options.excludeSimilar) {
-    charset = charset.split('').filter(char => !SIMILAR_CHARS.includes(char)).join('')
+    charset = charset
+      .split('')
+      .filter(char => !SIMILAR_CHARS.includes(char))
+      .join('')
   }
 
   if (options.excludeAmbiguous) {
-    charset = charset.split('').filter(char => !AMBIGUOUS_CHARS.includes(char)).join('')
+    charset = charset
+      .split('')
+      .filter(char => !AMBIGUOUS_CHARS.includes(char))
+      .join('')
   }
 
   return charset
 }
 
-export function getSecureRandomInt(max: number, cryptoImpl?: { getRandomValues: (arr: Uint32Array) => void }): number {
+export function getSecureRandomInt(
+  max: number,
+  cryptoImpl?: { getRandomValues: (arr: Uint32Array) => void }
+): number {
   const crypto = cryptoImpl ?? (typeof globalThis !== 'undefined' ? globalThis.crypto : undefined)
   if (crypto && crypto.getRandomValues) {
     const array = new Uint32Array(1)

--- a/tools/regex-tester/utils/regex-utils.ts
+++ b/tools/regex-tester/utils/regex-utils.ts
@@ -20,30 +20,34 @@ export function buildFlagString(flags: RegexFlags): string {
   return flagString
 }
 
-export function parseRegexMatches(pattern: string, testString: string, flags: RegexFlags): RegexMatch[] {
+export function parseRegexMatches(
+  pattern: string,
+  testString: string,
+  flags: RegexFlags
+): RegexMatch[] {
   const flagString = buildFlagString(flags)
   const regex = new RegExp(pattern, flagString)
   const foundMatches: RegexMatch[] = []
-  let match: RegExpExecArray | null
-
   if (flags.global) {
-    while ((match = regex.exec(testString)) !== null) {
+    let match = regex.exec(testString)
+    while (match !== null) {
       foundMatches.push({
         value: match[0],
         index: match.index!,
-        groups: match.slice(1)
+        groups: match.slice(1),
       })
       if (match[0] === '') {
         regex.lastIndex++
       }
+      match = regex.exec(testString)
     }
   } else {
-    match = regex.exec(testString)
+    const match = regex.exec(testString)
     if (match) {
       foundMatches.push({
         value: match[0],
         index: match.index!,
-        groups: match.slice(1)
+        groups: match.slice(1),
       })
     }
   }

--- a/tools/shared/components/types.ts
+++ b/tools/shared/components/types.ts
@@ -5,59 +5,59 @@
  * used across all 23 developer tools.
  */
 
-import type { Ref } from 'vue';
+import type { Ref } from 'vue'
 
 export interface KofiButtonProps {
   /** Ko-fi username for donation link (always 'kterr') */
-  kofiUsername: string;
+  kofiUsername: string
 
   /** Scroll percentage threshold for visibility toggle (default: 70) */
-  threshold?: number;
+  threshold?: number
 
   /** Animation duration in milliseconds (default: 300) */
-  animationDuration?: number;
+  animationDuration?: number
 
   /** Button position on screen (default: 'bottom-left') */
-  position?: 'bottom-left' | 'bottom-right';
+  position?: 'bottom-left' | 'bottom-right'
 }
 
 export interface KofiButtonEmits {
   /** Emitted when button becomes visible */
-  'kofi:shown': [];
+  'kofi:shown': []
 
   /** Emitted when button becomes hidden */
-  'kofi:hidden': [];
+  'kofi:hidden': []
 
   /** Emitted when button is clicked */
-  'kofi:clicked': [];
+  'kofi:clicked': []
 }
 
 export interface ScrollPositionComposable {
   /** Current scroll percentage (0-100) */
-  scrollPercentage: Ref<number>;
+  scrollPercentage: Ref<number>
 
   /** Whether scroll position is at or beyond threshold */
-  isAtThreshold: Ref<boolean>;
+  isAtThreshold: Ref<boolean>
 
   /** Whether page content is shorter than viewport */
-  isShortPage: Ref<boolean>;
+  isShortPage: Ref<boolean>
 
   /** Auto-detected scroll container element */
-  scrollContainer: Ref<HTMLElement | null>;
+  scrollContainer: Ref<HTMLElement | null>
 }
 
 export interface ScrollDetectionUtils {
   /** Auto-detect appropriate scroll container for the current page layout */
-  detectScrollContainer(): HTMLElement;
+  detectScrollContainer(): HTMLElement
 
   /** Calculate scroll percentage for given container */
-  calculateScrollPercentage(container: HTMLElement): number;
+  calculateScrollPercentage(container: HTMLElement): number
 
   /** Check if page content is shorter than viewport */
-  isPageContentShort(container: HTMLElement): boolean;
+  isPageContentShort(container: HTMLElement): boolean
 
   /** Throttle scroll event handler */
-  throttleScrollEvent(handler: () => void, delay: number): () => void;
+  throttleScrollEvent(handler: () => void, delay: number): () => void
 }
 
 /**
@@ -65,22 +65,22 @@ export interface ScrollDetectionUtils {
  */
 export interface KofiButtonState {
   /** Current visibility state (computed from scroll position) */
-  isVisible: boolean;
+  isVisible: boolean
 
   /** Whether scroll position is at or beyond 70% threshold */
-  isAtThreshold: boolean;
+  isAtThreshold: boolean
 
   /** Whether page content is shorter than viewport height */
-  isShortPage: boolean;
+  isShortPage: boolean
 
   /** CSS transition duration in milliseconds (default: 300) */
-  animationDuration: number;
+  animationDuration: number
 
   /** Scroll percentage threshold for state change (default: 70) */
-  threshold: number;
+  threshold: number
 
   /** Button positioning (default: 'bottom-left') */
-  position: 'bottom-left' | 'bottom-right';
+  position: 'bottom-left' | 'bottom-right'
 }
 
 /**
@@ -88,22 +88,22 @@ export interface KofiButtonState {
  */
 export interface ScrollPosition {
   /** Current vertical scroll position in pixels */
-  scrollTop: number;
+  scrollTop: number
 
   /** Total scrollable height of the detected container */
-  scrollHeight: number;
+  scrollHeight: number
 
   /** Viewport height of the detected container */
-  clientHeight: number;
+  clientHeight: number
 
   /** Calculated scroll percentage (0-100) */
-  scrollPercentage: number;
+  scrollPercentage: number
 
   /** Auto-detected scroll container (document.body or main content) */
-  container: HTMLElement;
+  container: HTMLElement
 
   /** Whether scroll events are currently throttled */
-  isThrottled: boolean;
+  isThrottled: boolean
 }
 
 /**
@@ -111,17 +111,17 @@ export interface ScrollPosition {
  */
 export interface ToolIntegration {
   /** Name of the tool (e.g., 'hash-generator', 'qr-generator') */
-  toolName: string;
+  toolName: string
 
   /** Ko-fi username (always 'kterr') */
-  kofiUsername: string;
+  kofiUsername: string
 
   /** Whether tool has non-standard layout requiring special handling */
-  hasCustomLayout: boolean;
+  hasCustomLayout: boolean
 
   /** Auto-detected or manually specified scroll container */
-  scrollContainer: HTMLElement | null;
+  scrollContainer: HTMLElement | null
 
   /** Whether E2E tests are implemented for this tool */
-  testCoverage: boolean;
+  testCoverage: boolean
 }

--- a/tools/shared/composables/useKofiWidget.ts
+++ b/tools/shared/composables/useKofiWidget.ts
@@ -3,7 +3,7 @@
  * Provides Ko-fi donation widget functionality across all dev tools
  */
 
-import { ref, readonly, type Ref } from 'vue'
+import { type Ref, readonly, ref } from 'vue'
 import type { KofiWidgetConfig, KofiWidgetState } from '../types/kofi'
 
 declare global {
@@ -20,7 +20,7 @@ export function useKofiWidget() {
   const state: Ref<KofiWidgetState> = ref({
     isLoaded: false,
     isVisible: false,
-    loadError: false
+    loadError: false,
   })
 
   let config: KofiWidgetConfig | null = null
@@ -34,7 +34,7 @@ export function useKofiWidget() {
     state.value = {
       isLoaded: false,
       isVisible: false,
-      loadError: false
+      loadError: false,
     }
   }
 
@@ -77,7 +77,6 @@ export function useKofiWidget() {
           handleLoadError()
         }
       }, 5000)
-
     } catch (error) {
       console.error('Failed to load Ko-fi widget:', error)
       handleLoadError()
@@ -96,10 +95,10 @@ export function useKofiWidget() {
     try {
       // Create Ko-fi widget configuration
       const kofiConfig = {
-        'type': config.type,
+        type: config.type,
         'floating-chat.donateButton.text': config.buttonText,
         'floating-chat.donateButton.background-color': config.backgroundColor,
-        'floating-chat.donateButton.text-color': config.textColor
+        'floating-chat.donateButton.text-color': config.textColor,
       }
 
       // Initialize Ko-fi widget
@@ -109,9 +108,8 @@ export function useKofiWidget() {
       state.value = {
         isLoaded: true,
         isVisible: true,
-        loadError: false
+        loadError: false,
       }
-
     } catch (error) {
       console.error('Failed to initialize Ko-fi widget:', error)
       handleLoadError()
@@ -125,7 +123,7 @@ export function useKofiWidget() {
     state.value = {
       isLoaded: false,
       isVisible: false,
-      loadError: true
+      loadError: true,
     }
     // Silent failure - no error messages to user
   }
@@ -154,7 +152,7 @@ export function useKofiWidget() {
       state: readonly(state),
       load,
       hide,
-      show
+      show,
     })
   }
 
@@ -163,6 +161,6 @@ export function useKofiWidget() {
     state: readonly(state),
     load,
     hide,
-    show
+    show,
   }
 }

--- a/tools/shared/composables/useScrollPosition.ts
+++ b/tools/shared/composables/useScrollPosition.ts
@@ -1,18 +1,18 @@
-import { ref, onMounted, onUnmounted } from 'vue';
-import type { Ref } from 'vue';
+import type { Ref } from 'vue'
+import { onMounted, onUnmounted, ref } from 'vue'
 import {
-  detectScrollContainer,
   calculateScrollPercentage,
+  detectScrollContainer,
   isPageContentShort,
-  throttleScrollEvent
-} from '../utils/scroll-detection';
+  throttleScrollEvent,
+} from '../utils/scroll-detection'
 
 interface ScrollPositionReturn {
-  scrollPercentage: Ref<number>;
-  isAtThreshold: Ref<boolean>;
-  isShortPage: Ref<boolean>;
-  scrollContainer: Ref<HTMLElement | null>;
-  cleanup: () => void;
+  scrollPercentage: Ref<number>
+  isAtThreshold: Ref<boolean>
+  isShortPage: Ref<boolean>
+  scrollContainer: Ref<HTMLElement | null>
+  cleanup: () => void
 }
 
 /**
@@ -24,134 +24,134 @@ interface ScrollPositionReturn {
  * @returns ScrollPositionReturn - Reactive scroll state
  */
 export function useScrollPosition(threshold: number = 70): ScrollPositionReturn {
-  const scrollPercentage = ref(0);
-  const isAtThreshold = ref(false);
-  const isShortPage = ref(false);
-  const scrollContainer = ref<HTMLElement | null>(null);
+  const scrollPercentage = ref(0)
+  const isAtThreshold = ref(false)
+  const isShortPage = ref(false)
+  const scrollContainer = ref<HTMLElement | null>(null)
 
-  let throttledHandler: (() => void) | null = null;
-  let resizeHandler: (() => void) | null = null;
+  let throttledHandler: (() => void) | null = null
+  let resizeHandler: (() => void) | null = null
 
   const calculateScrollState = (): void => {
-    const container = scrollContainer.value;
+    const container = scrollContainer.value
     if (!container) {
-      return;
+      return
     }
 
     // Check if page is too short to scroll
-    const isShort = isPageContentShort(container);
-    isShortPage.value = isShort;
+    const isShort = isPageContentShort(container)
+    isShortPage.value = isShort
 
     if (isShort) {
-      scrollPercentage.value = 0;
-      isAtThreshold.value = false;
-      return;
+      scrollPercentage.value = 0
+      isAtThreshold.value = false
+      return
     }
 
     // Calculate scroll percentage
-    const percentage = calculateScrollPercentage(container);
-    scrollPercentage.value = percentage;
+    const percentage = calculateScrollPercentage(container)
+    scrollPercentage.value = percentage
 
     // Check if at or beyond threshold
-    isAtThreshold.value = percentage >= threshold;
-  };
+    isAtThreshold.value = percentage >= threshold
+  }
 
   const handleResize = (): void => {
     // Re-detect scroll container on resize as layout may have changed
-    const newContainer = detectScrollContainer();
+    const newContainer = detectScrollContainer()
     if (newContainer !== scrollContainer.value) {
       // Remove old listeners
       if (scrollContainer.value && throttledHandler) {
         if (scrollContainer.value === document.body) {
-          window.removeEventListener('scroll', throttledHandler);
+          window.removeEventListener('scroll', throttledHandler)
         } else {
-          scrollContainer.value.removeEventListener('scroll', throttledHandler);
+          scrollContainer.value.removeEventListener('scroll', throttledHandler)
         }
       }
 
       // Update container reference
-      scrollContainer.value = newContainer;
+      scrollContainer.value = newContainer
 
       // Add new listeners
       if (throttledHandler) {
         if (newContainer === document.body) {
-          window.addEventListener('scroll', throttledHandler, { passive: true });
+          window.addEventListener('scroll', throttledHandler, { passive: true })
         } else {
-          newContainer.addEventListener('scroll', throttledHandler, { passive: true });
+          newContainer.addEventListener('scroll', throttledHandler, { passive: true })
         }
       }
     }
 
     // Recalculate scroll state
-    calculateScrollState();
-  };
+    calculateScrollState()
+  }
 
   const cleanup = (): void => {
     if (scrollContainer.value && throttledHandler) {
       if (scrollContainer.value === document.body) {
-        window.removeEventListener('scroll', throttledHandler);
+        window.removeEventListener('scroll', throttledHandler)
       } else {
-        scrollContainer.value.removeEventListener('scroll', throttledHandler);
+        scrollContainer.value.removeEventListener('scroll', throttledHandler)
       }
     }
 
     if (resizeHandler) {
-      window.removeEventListener('resize', resizeHandler);
-      window.removeEventListener('orientationchange', resizeHandler);
+      window.removeEventListener('resize', resizeHandler)
+      window.removeEventListener('orientationchange', resizeHandler)
     }
 
-    throttledHandler = null;
-    resizeHandler = null;
-  };
+    throttledHandler = null
+    resizeHandler = null
+  }
 
   const initializeScrollDetection = (): void => {
     try {
       // Auto-detect the appropriate scroll container
-      scrollContainer.value = detectScrollContainer();
+      scrollContainer.value = detectScrollContainer()
 
       // Create throttled scroll handler
-      throttledHandler = throttleScrollEvent(calculateScrollState, 100);
+      throttledHandler = throttleScrollEvent(calculateScrollState, 100)
 
       // Create throttled resize handler
-      resizeHandler = throttleScrollEvent(handleResize, 100);
+      resizeHandler = throttleScrollEvent(handleResize, 100)
 
       // Initial calculation
-      calculateScrollState();
+      calculateScrollState()
 
       // Add event listeners
       if (scrollContainer.value === document.body) {
-        window.addEventListener('scroll', throttledHandler, { passive: true });
+        window.addEventListener('scroll', throttledHandler, { passive: true })
       } else {
-        scrollContainer.value.addEventListener('scroll', throttledHandler, { passive: true });
+        scrollContainer.value.addEventListener('scroll', throttledHandler, { passive: true })
       }
 
-      window.addEventListener('resize', resizeHandler);
-      window.addEventListener('orientationchange', resizeHandler);
+      window.addEventListener('resize', resizeHandler)
+      window.addEventListener('orientationchange', resizeHandler)
     } catch (error) {
-      console.warn('Error initializing scroll detection:', error);
+      console.warn('Error initializing scroll detection:', error)
 
       // Fallback to basic document body detection
-      scrollContainer.value = document.body;
-      isShortPage.value = document.documentElement.scrollHeight <= window.innerHeight;
-      scrollPercentage.value = 0;
-      isAtThreshold.value = false;
+      scrollContainer.value = document.body
+      isShortPage.value = document.documentElement.scrollHeight <= window.innerHeight
+      scrollPercentage.value = 0
+      isAtThreshold.value = false
     }
-  };
+  }
 
   onMounted(() => {
     // Use nextTick equivalent to ensure DOM is ready
-    setTimeout(initializeScrollDetection, 0);
-  });
+    setTimeout(initializeScrollDetection, 0)
+  })
 
   onUnmounted(() => {
-    cleanup();
-  });
+    cleanup()
+  })
 
   return {
     scrollPercentage,
     isAtThreshold,
     isShortPage,
     scrollContainer,
-    cleanup
-  };
+    cleanup,
+  }
 }

--- a/tools/shared/config/kofi.ts
+++ b/tools/shared/config/kofi.ts
@@ -10,7 +10,7 @@ export const KOFI_CONFIG: KofiWidgetConfig = {
   type: 'floating-chat',
   buttonText: 'Support me',
   backgroundColor: '#00b9fe',
-  textColor: '#fff'
+  textColor: '#fff',
 }
 
 /**

--- a/tools/shared/config/security-headers.ts
+++ b/tools/shared/config/security-headers.ts
@@ -15,7 +15,7 @@ export const SECURITY_HEADERS = {
   'X-Content-Type-Options': 'nosniff',
   'X-Frame-Options': 'DENY',
   'X-XSS-Protection': '1; mode=block',
-  'Referrer-Policy': 'strict-origin-when-cross-origin'
+  'Referrer-Policy': 'strict-origin-when-cross-origin',
 }
 
 /**
@@ -24,8 +24,8 @@ export const SECURITY_HEADERS = {
  */
 export const getSecurityHeadersRouteRules = () => ({
   '/**': {
-    headers: SECURITY_HEADERS
-  }
+    headers: SECURITY_HEADERS,
+  },
 })
 
 export default SECURITY_HEADERS

--- a/tools/shared/types/kofi.ts
+++ b/tools/shared/types/kofi.ts
@@ -4,17 +4,17 @@
  */
 
 export interface KofiWidgetConfig {
-  accountId: string;
-  type: 'floating-chat';
-  buttonText: string;
-  backgroundColor: string;
-  textColor: string;
+  accountId: string
+  type: 'floating-chat'
+  buttonText: string
+  backgroundColor: string
+  textColor: string
 }
 
 export interface KofiWidgetState {
-  isLoaded: boolean;
-  isVisible: boolean;
-  loadError: boolean;
+  isLoaded: boolean
+  isVisible: boolean
+  loadError: boolean
 }
 
 export interface UseKofiWidget {
@@ -22,26 +22,26 @@ export interface UseKofiWidget {
    * Initialize Ko-fi widget with configuration
    * @param config - Widget configuration object
    */
-  init(config: KofiWidgetConfig): void;
+  init(config: KofiWidgetConfig): void
 
   /**
    * Current widget state (reactive)
    */
-  readonly state: Readonly<Ref<KofiWidgetState>>;
+  readonly state: Readonly<Ref<KofiWidgetState>>
 
   /**
    * Load Ko-fi script and initialize widget
    * Returns promise that resolves when script loads or fails
    */
-  load(): Promise<void>;
+  load(): Promise<void>
 
   /**
    * Manually hide widget (for error states)
    */
-  hide(): void;
+  hide(): void
 
   /**
    * Manually show widget (if script loaded successfully)
    */
-  show(): void;
+  show(): void
 }

--- a/tools/shared/utils/scroll-detection.ts
+++ b/tools/shared/utils/scroll-detection.ts
@@ -6,9 +6,9 @@
  */
 
 export interface ScrollDetectionResult {
-  container: HTMLElement;
-  isShortPage: boolean;
-  scrollableHeight: number;
+  container: HTMLElement
+  isShortPage: boolean
+  scrollableHeight: number
 }
 
 /**
@@ -17,24 +17,26 @@ export interface ScrollDetectionResult {
  */
 export function detectScrollContainer(): HTMLElement {
   // Check for explicitly scrollable containers first
-  const scrollableContainers = document.querySelectorAll([
-    'main[style*="overflow"]',
-    'section[style*="overflow"]',
-    'div[style*="overflow"]',
-    '.scroll-container',
-    '[data-scroll-container]'
-  ].join(','));
+  const scrollableContainers = document.querySelectorAll(
+    [
+      'main[style*="overflow"]',
+      'section[style*="overflow"]',
+      'div[style*="overflow"]',
+      '.scroll-container',
+      '[data-scroll-container]',
+    ].join(',')
+  )
 
   for (const container of scrollableContainers) {
-    const element = container as HTMLElement;
-    const styles = window.getComputedStyle(element);
+    const element = container as HTMLElement
+    const styles = window.getComputedStyle(element)
 
     // Check if container is actually scrollable
     if (
       (styles.overflowY === 'auto' || styles.overflowY === 'scroll') &&
       element.scrollHeight > element.clientHeight
     ) {
-      return element;
+      return element
     }
   }
 
@@ -43,22 +45,22 @@ export function detectScrollContainer(): HTMLElement {
     document.querySelector('main'),
     document.querySelector('#main'),
     document.querySelector('.main-content'),
-    document.querySelector('[role="main"]')
-  ].filter(Boolean) as HTMLElement[];
+    document.querySelector('[role="main"]'),
+  ].filter(Boolean) as HTMLElement[]
 
   for (const main of mainElements) {
     if (main.scrollHeight > main.clientHeight) {
-      return main;
+      return main
     }
   }
 
   // Check if document body is scrollable
   if (document.documentElement.scrollHeight > window.innerHeight) {
-    return document.body;
+    return document.body
   }
 
   // Fallback to document body
-  return document.body;
+  return document.body
 }
 
 /**
@@ -68,39 +70,39 @@ export function detectScrollContainer(): HTMLElement {
  */
 export function calculateScrollPercentage(container: HTMLElement): number {
   if (!container) {
-    return 0;
+    return 0
   }
 
   try {
-    let scrollTop: number;
-    let scrollHeight: number;
-    let clientHeight: number;
+    let scrollTop: number
+    let scrollHeight: number
+    let clientHeight: number
 
     if (container === document.body) {
       // For document body, use window scroll properties
-      scrollTop = window.scrollY || window.pageYOffset;
-      scrollHeight = document.documentElement.scrollHeight;
-      clientHeight = window.innerHeight;
+      scrollTop = window.scrollY || window.pageYOffset
+      scrollHeight = document.documentElement.scrollHeight
+      clientHeight = window.innerHeight
     } else {
       // For other containers, use element properties
-      scrollTop = container.scrollTop;
-      scrollHeight = container.scrollHeight;
-      clientHeight = container.clientHeight;
+      scrollTop = container.scrollTop
+      scrollHeight = container.scrollHeight
+      clientHeight = container.clientHeight
     }
 
-    const scrollableHeight = scrollHeight - clientHeight;
+    const scrollableHeight = scrollHeight - clientHeight
 
     // Handle cases where there's no scrollable content
     if (scrollableHeight <= 0) {
-      return 0;
+      return 0
     }
 
     // Calculate percentage
-    const percentage = Math.min(100, Math.max(0, (scrollTop / scrollableHeight) * 100));
-    return percentage;
+    const percentage = Math.min(100, Math.max(0, (scrollTop / scrollableHeight) * 100))
+    return percentage
   } catch (error) {
-    console.warn('Error calculating scroll percentage:', error);
-    return 0;
+    console.warn('Error calculating scroll percentage:', error)
+    return 0
   }
 }
 
@@ -111,18 +113,18 @@ export function calculateScrollPercentage(container: HTMLElement): number {
  */
 export function isPageContentShort(container: HTMLElement): boolean {
   if (!container) {
-    return true;
+    return true
   }
 
   try {
     if (container === document.body) {
-      return document.documentElement.scrollHeight <= window.innerHeight;
+      return document.documentElement.scrollHeight <= window.innerHeight
     } else {
-      return container.scrollHeight <= container.clientHeight;
+      return container.scrollHeight <= container.clientHeight
     }
   } catch (error) {
-    console.warn('Error checking page content height:', error);
-    return true;
+    console.warn('Error checking page content height:', error)
+    return true
   }
 }
 
@@ -132,33 +134,33 @@ export function isPageContentShort(container: HTMLElement): boolean {
  * @param delay - Throttle delay in milliseconds (default: 100)
  * @returns Function - Throttled handler function
  */
-export function throttleScrollEvent(
-  handler: () => void,
-  delay: number = 100
-): () => void {
-  let timeoutId: NodeJS.Timeout | null = null;
-  let lastExecTime = 0;
+export function throttleScrollEvent(handler: () => void, delay: number = 100): () => void {
+  let timeoutId: NodeJS.Timeout | null = null
+  let lastExecTime = 0
 
   return function throttledHandler() {
-    const currentTime = Date.now();
+    const currentTime = Date.now()
 
     if (currentTime - lastExecTime >= delay) {
       // Execute immediately if enough time has passed
-      handler();
-      lastExecTime = currentTime;
+      handler()
+      lastExecTime = currentTime
     } else {
       // Schedule execution for later
       if (timeoutId) {
-        clearTimeout(timeoutId);
+        clearTimeout(timeoutId)
       }
 
-      timeoutId = setTimeout(() => {
-        handler();
-        lastExecTime = Date.now();
-        timeoutId = null;
-      }, delay - (currentTime - lastExecTime));
+      timeoutId = setTimeout(
+        () => {
+          handler()
+          lastExecTime = Date.now()
+          timeoutId = null
+        },
+        delay - (currentTime - lastExecTime)
+      )
     }
-  };
+  }
 }
 
 /**
@@ -167,31 +169,31 @@ export function throttleScrollEvent(
  * @returns ScrollDetectionResult - Complete scroll detection data
  */
 export function getScrollDetectionInfo(threshold: number = 70): ScrollDetectionResult {
-  const container = detectScrollContainer();
-  const isShort = isPageContentShort(container);
-  const percentage = calculateScrollPercentage(container);
+  const container = detectScrollContainer()
+  const isShort = isPageContentShort(container)
+  const percentage = calculateScrollPercentage(container)
 
-  let scrollableHeight: number;
+  let scrollableHeight: number
 
   if (container === document.body) {
-    scrollableHeight = document.documentElement.scrollHeight - window.innerHeight;
+    scrollableHeight = document.documentElement.scrollHeight - window.innerHeight
   } else {
-    scrollableHeight = container.scrollHeight - container.clientHeight;
+    scrollableHeight = container.scrollHeight - container.clientHeight
   }
 
   return {
     container,
     isShortPage: isShort,
-    scrollableHeight: Math.max(0, scrollableHeight)
-  };
+    scrollableHeight: Math.max(0, scrollableHeight),
+  }
 }
 
 /**
  * Expose utilities to global scope for testing
  */
 if (typeof window !== 'undefined') {
-  (window as any).detectScrollContainer = detectScrollContainer;
-  (window as any).calculateScrollPercentage = calculateScrollPercentage;
-  (window as any).isPageContentShort = isPageContentShort;
-  (window as any).throttleScrollEvent = throttleScrollEvent;
+  ;(window as any).detectScrollContainer = detectScrollContainer
+  ;(window as any).calculateScrollPercentage = calculateScrollPercentage
+  ;(window as any).isPageContentShort = isPageContentShort
+  ;(window as any).throttleScrollEvent = throttleScrollEvent
 }

--- a/tools/string-converter/utils/string-utils.ts
+++ b/tools/string-converter/utils/string-utils.ts
@@ -38,7 +38,10 @@ export function snakeToCamel(input: string): string {
 
 export function camelToSnake(input: string): string {
   if (!input) return ''
-  return input.replace(/([A-Z])/g, '_$1').toLowerCase().replace(/^_/, '')
+  return input
+    .replace(/([A-Z])/g, '_$1')
+    .toLowerCase()
+    .replace(/^_/, '')
 }
 
 export function toUpperCase(input: string): string {

--- a/tools/unix-time-converter/utils/time-utils.ts
+++ b/tools/unix-time-converter/utils/time-utils.ts
@@ -16,7 +16,7 @@ export function convertUnixToHuman(unixTimestamp: number): UnixToHumanResult {
   const date = new Date(unixTimestamp * 1000)
   return {
     local: date.toLocaleString(),
-    utc: date.toUTCString()
+    utc: date.toUTCString(),
   }
 }
 
@@ -34,6 +34,6 @@ export function convertHumanToUnix(dateStr: string, timeStr: string): HumanToUni
 
   return {
     local: Math.floor(localDate.getTime() / 1000).toString(),
-    utc: Math.floor(utcDate.getTime() / 1000).toString()
+    utc: Math.floor(utcDate.getTime() / 1000).toString(),
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from 'vitest/config'
 import { resolve } from 'path'
+import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   esbuild: {
@@ -11,8 +11,8 @@ export default defineConfig({
         moduleResolution: 'bundler',
         esModuleInterop: true,
         strict: true,
-      }
-    }
+      },
+    },
   },
   test: {
     globals: true,
@@ -22,11 +22,11 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
       include: ['tools/*/utils/**/*.ts', 'tools/shared/utils/**/*.ts'],
-    }
+    },
   },
   resolve: {
     alias: {
-      '@shared': resolve(__dirname, 'tools/shared')
-    }
-  }
+      '@shared': resolve(__dirname, 'tools/shared'),
+    },
+  },
 })


### PR DESCRIPTION
## 概要

ルートレベルの TypeScript ファイル（`tests/`・`tools/*/utils/`・`tools/shared/`）を対象に、Biome 2.4.7 + Oxlint 1.56.0 によるフォーマット・lint 基盤を整備した。
各ツールの Vue ファイルは引き続き per-tool ESLint が担当する。

## 変更内容

- **`biome.json`** 新規作成：formatter（セミコロンなし・シングルクォート・2スペース）+ linter（recommended + カスタムルール）+ assist（import 整理）
- **`.oxlintrc.json`** 新規作成：typescript プラグイン設定（`no-explicit-any`・`no-non-null-assertion`・`no-unnecessary-type-assertion` 等）
- **`package.json`**: `@biomejs/biome@2.4.7`・`oxlint@1.56.0` を devDependencies に追加、`format`/`format:check`/`lint`/`lint:biome`/`lint:oxlint`/`check` スクリプト追加
- **既存ファイル一括フォーマット**: `biome check --write` で `tests/`・`tools/*/utils/`・`tools/shared/`・`vitest.config.ts`・`playwright.config.ts` を整形（スタイルのみ、ロジック変更なし）
- **`tools/regex-tester/utils/regex-utils.ts`**: `noAssignInExpressions` エラーを解消（`while ((match = ...))` → 明示的な変数割り当てにリファクタ）
- **`lefthook.yml`**: pre-commit に `format-check`（Biome フォーマットチェック）・`lint-staged`（Biome + Oxlint lint）コマンドを追加
- **`.claude/hooks/post-tool-use-format-and-lint.sh`**: Biome スコープの `.ts` ファイルを `biome format --write` + `oxlint` で自動処理するよう拡張
- **`Makefile`**: `format`/`format-check`/`lint`/`check` ターゲット追加、既存の `lint` を `lint-tool` にリネーム

## テスト方法

- [ ] `npm run format:check` → "No fixes applied" でパスすること
- [ ] `npm run lint` → warnings のみ、errors なし（exit 0）でパスすること
- [ ] `npm run test:unit` → 109/109 テスト全通過

## チェックリスト

- [x] テストを追加・更新した（既存テストが全通過）
- [x] ドキュメントを更新した（MEMORY.md 更新）
- [ ] ユーザー向けテキストの i18n 対応を行った（該当なし）