### PR TITLE
chore: Makefile にデプロイ用ターゲットを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,12 @@
-.PHONY: test test-unit test-unit-watch test-unit-coverage test-e2e test-e2e-dev test-all lint lint-tool format format-check check help
+.PHONY: test test-unit test-unit-watch test-unit-coverage test-e2e test-e2e-dev test-all lint lint-tool format format-check check build deploy deploy-s3 deploy-invalidate help
+
+ENV ?= dev
+
+TOOLS := hash-generator qr-generator unix-time-converter password-generator ip-calculator \
+         markdown-preview placeholder-generator ip-info timezone-converter string-converter \
+         code-diff mic-test json-yaml-converter jwt-decoder regex-tester lorem-ipsum-generator \
+         image-converter timer character-code-converter badger-image-generator poster-splitter \
+         map-distance-calculator amazon-url-normalizer landing-page
 
 # Default target
 .DEFAULT_GOAL := test
@@ -55,6 +63,62 @@ endif
 ## Format + lint + import organize in one pass
 check:
 	npx biome check --write tests/ tools/*/utils/ tools/shared/ vitest.config.ts playwright.config.ts
+
+## Build a specific tool (TOOL=<tool-name> required)
+build:
+ifndef TOOL
+	@echo "Usage: make build TOOL=<tool-name>"
+	@exit 1
+endif
+	cd tools/$(TOOL) && npm ci && npm run generate
+
+## Sync built output to S3 (TOOL=<tool-name> required, ENV=dev|prd default=dev)
+deploy-s3:
+ifndef TOOL
+	@echo "Usage: make deploy-s3 TOOL=<tool-name> [ENV=dev]"
+	@exit 1
+endif
+	@STACK_NAME="DevToolsStack-$(ENV)"; \
+	TOOL_KEY=$$(echo "$(TOOL)" | tr -d '-'); \
+	BUCKET_NAME=$$(aws cloudformation describe-stacks \
+	  --stack-name "$$STACK_NAME" \
+	  --query "Stacks[0].Outputs[?OutputKey=='$${TOOL_KEY}bucketname'].OutputValue" \
+	  --output text); \
+	echo "Syncing to s3://$$BUCKET_NAME/"; \
+	aws s3 sync tools/$(TOOL)/.output/public/ s3://$$BUCKET_NAME/ --delete
+
+## Invalidate CloudFront cache (TOOL=<tool-name> required, ENV=dev|prd default=dev)
+deploy-invalidate:
+ifndef TOOL
+	@echo "Usage: make deploy-invalidate TOOL=<tool-name> [ENV=dev]"
+	@exit 1
+endif
+	@STACK_NAME="DevToolsStack-$(ENV)"; \
+	TOOL_KEY=$$(echo "$(TOOL)" | tr -d '-'); \
+	DISTRIBUTION_ID=$$(aws cloudformation describe-stacks \
+	  --stack-name "$$STACK_NAME" \
+	  --query "Stacks[0].Outputs[?OutputKey=='$${TOOL_KEY}distributionid'].OutputValue" \
+	  --output text); \
+	echo "Invalidating CloudFront distribution $$DISTRIBUTION_ID"; \
+	aws cloudfront create-invalidation \
+	  --distribution-id "$$DISTRIBUTION_ID" \
+	  --paths "/*"
+
+## Full deploy: build + S3 sync + CloudFront invalidation (TOOL=<tool> for single tool, omit for all tools, ENV=dev|prd default=dev)
+deploy:
+ifdef TOOL
+	$(MAKE) build TOOL=$(TOOL) ENV=$(ENV)
+	$(MAKE) deploy-s3 TOOL=$(TOOL) ENV=$(ENV)
+	$(MAKE) deploy-invalidate TOOL=$(TOOL) ENV=$(ENV)
+else
+	@for tool in $(TOOLS); do \
+	  echo "=== Deploying $$tool ($(ENV)) ==="; \
+	  $(MAKE) build TOOL=$$tool ENV=$(ENV) && \
+	  $(MAKE) deploy-s3 TOOL=$$tool ENV=$(ENV) && \
+	  $(MAKE) deploy-invalidate TOOL=$$tool ENV=$(ENV) \
+	  || echo "ERROR: $$tool deploy failed"; \
+	done
+endif
 
 ## Show available targets
 help:


### PR DESCRIPTION
## 概要

`deploy.yml` に定義されているデプロイフロー（ビルド → S3 sync → CloudFront 無効化）を Makefile に集約し、ローカルから簡単にデプロイできるようにした。

## 変更内容

- `TOOLS` 変数を追加（deploy.yml の全24ツールリストと同一）
- `ENV` 変数を追加（デフォルト `dev`、`ENV=prd` で本番切り替え）
- `build`: `npm ci && npm run generate` でツールをビルド
- `deploy-s3`: CloudFormation スタックからバケット名を取得し `aws s3 sync` で同期
- `deploy-invalidate`: CloudFormation スタックから Distribution ID を取得し CloudFront キャッシュ無効化
- `deploy`: 上記3ステップを統合。`TOOL=<name>` で単一ツール、省略で全ツールをループデプロイ

## テスト方法

```bash
# 単一ツールのビルド確認
make build TOOL=ip-calculator

# S3 sync（AWS 認証情報が必要）
make deploy-s3 TOOL=ip-calculator ENV=dev

# 全ツール一括デプロイ
make deploy ENV=dev
```

## チェックリスト

- [x] テストを追加・更新した（Makefile 変更のためテスト対象外）
- [x] ドキュメントを更新した（コメントで使用方法を記載）
- [ ] ユーザー向けテキストの i18n 対応を行った（該当なし）